### PR TITLE
Renamed Zambian Kwacha from ZMK to ZMW

### DIFF
--- a/lib/iso_country_codes/iso_4217.rb
+++ b/lib/iso_country_codes/iso_4217.rb
@@ -103,7 +103,7 @@ class IsoCountryCodes
       self.main_currency = 'KRW'
     end
     class ZMB < Code #:nodoc:
-      self.main_currency = 'ZMK'
+      self.main_currency = 'ZMW'
     end
     class MKD < Code #:nodoc:
       self.main_currency = 'MKD'


### PR DESCRIPTION
Hi Alex

Effective 1st Jan 2013 the Zambian Kwacha was renamed from ZMK to ZMW (see http://en.wikipedia.org/wiki/Zambian_kwacha)

I'd be grateful if you could merge this commit and issue a point release

Thanks for maintaining this useful gem

Rob
