### PR TITLE
Latvian LAT was replaced with the Euro on 1 January 2014

### DIFF
--- a/lib/iso_country_codes/iso_4217.rb
+++ b/lib/iso_country_codes/iso_4217.rb
@@ -744,7 +744,7 @@ class IsoCountryCodes
       self.main_currency = 'KGS'
     end
     class EST < Code #:nodoc:
-      self.main_currency = 'EEK'
+      self.main_currency = 'EUR'
     end
     class GNB < Code #:nodoc:
       self.main_currency = 'XOF'


### PR DESCRIPTION
Hi Alex

Latvian LAT was replaced by the Euro on 1st Jan 2014 - see Wikipedia http://en.wikipedia.org/wiki/Latvia

I'd be grateful if you could merge this commit and issue a point release as before

Cheers

Rob
