### PR TITLE
Fix typo in Vietnam country name

### DIFF
--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -898,7 +898,7 @@ class IsoCountryCodes
     end
     class VNM < Code #:nodoc:
       self.numeric = %q{704}
-      self.name    = %q{Viet Nam}
+      self.name    = %q{Vietnam}
       self.alpha2  = %q{VN}
       self.alpha3  = %q{VNM}
     end


### PR DESCRIPTION
VNM name appears as "Viet Nam" but the country is called "Vietnam"
