### PR TITLE
The #search_by_name method should never raise a RegexpError

### DIFF
--- a/lib/iso_country_codes/iso_country_codes.rb
+++ b/lib/iso_country_codes/iso_country_codes.rb
@@ -39,8 +39,8 @@ class IsoCountryCodes # :nodoc:
       fallback ||= DEFAULT_FALLBACK
 
       instances = all.select { |c| c.name.upcase == str.upcase }
-      instances = all.select { |c| c.name.match(/^#{str}/i) } if instances.empty?
-      instances = all.select { |c| c.name.match(/#{str}/i) } if instances.empty?
+      instances = all.select { |c| c.name.match(/^#{Regexp.escape(str)}/i) } if instances.empty?
+      instances = all.select { |c| c.name.match(/#{Regexp.escape(str)}/i) } if instances.empty?
 
       return fallback.call "No ISO 3166-1 codes could be found searching with name '#{str}'." if instances.empty?
 

--- a/test/iso_country_codes_test.rb
+++ b/test/iso_country_codes_test.rb
@@ -92,6 +92,12 @@ class TestIsoCountryCodes < Test::Unit::TestCase
     assert_equal IsoCountryCodes.search_by_name('unknown country') {[]}, []
   end
 
+  def test_search_by_name_does_not_raise_regexp_error
+    assert_nothing_raised do
+      IsoCountryCodes.search_by_name('+ab'){[]}
+    end
+  end
+
   def test_search_by_name_exact_match
     assert_equal(
       [IsoCountryCodes::Code::CCK.instance],


### PR DESCRIPTION
Invalid input data should not raise an error, it should just return the normal failure/fallback result. The fact that the input is used to create a regular expression is an implementation detail, that shouldn't cause observable behavior. This change will make sure all user input is escaped so it is not interpreted as a regular expression.

If you do want to allow regular expression searches, it should require the user passing a regular expression, and the method should check for it explicitly:

```
if str.is_a?(Regexp)
  instances = all.select { |c| c.name.match(str) }
else
 ...
```