### PR TITLE
Ivory Coast -> english name, Cyprus in Europe

### DIFF
--- a/lib/iso_country_codes/continent.rb
+++ b/lib/iso_country_codes/continent.rb
@@ -159,7 +159,7 @@ class IsoCountryCodes
       self.continent = 'AS'
     end
     class CYP < Code #:nodoc:
-      self.continent = 'AS'
+      self.continent = 'EU'
     end
     class CZE < Code #:nodoc:
       self.continent = 'EU'

--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -328,7 +328,7 @@ class IsoCountryCodes
     end
     class CIV < Code #:nodoc:
       self.numeric = %q{384}
-      self.name    = %q{Côte d'Ivoire}
+      self.name    = %q{Ivory Coast}
       self.alpha2  = %q{CI}
       self.alpha3  = %q{CIV}
     end


### PR DESCRIPTION
Hi,

Maybe all countries name should be in english? I have changed Ivory Coast to english name.
Cyprus is rather in Europe (I also find that it's in Asia but more sources say about Europe) so I correct this too.