### PR TITLE
Add IBAN codes for Isle of Man, Guernsey and Jersey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * Fixed RegExp error in `search_by_name` (see #21)
 * Moved Cyprus from Asia to Europe
+* Added IBAN codes for British Crown Dependencies
 
 ## 0.7.1 - 2015-05-21
 

--- a/lib/iso_country_codes/iso_13616_1.rb
+++ b/lib/iso_country_codes/iso_13616_1.rb
@@ -69,6 +69,9 @@ class IsoCountryCodes
     class DEU < Code #:nodoc:
       self.iban = 'DE'
     end
+    class GGC < Code #:nodoc:
+      self.iban = 'GB'
+    end
     class GIB < Code #:nodoc:
       self.iban = 'GI'
     end
@@ -81,6 +84,9 @@ class IsoCountryCodes
     class HUN < Code #:nodoc:
       self.iban = 'HU'
     end
+    class IMN < Code #:nodoc:
+      self.iban = 'GB'
+    end
     class ISL < Code #:nodoc:
       self.iban = 'IS'
     end
@@ -92,6 +98,9 @@ class IsoCountryCodes
     end
     class ITA < Code #:nodoc:
       self.iban = 'IT'
+    end
+    class JEY < Code #:nodoc:
+      self.iban = 'GB'
     end
     class JOR < Code #:nodoc:
       self.iban = 'JO'

--- a/lib/iso_country_codes/iso_country_codes.rb
+++ b/lib/iso_country_codes/iso_country_codes.rb
@@ -38,9 +38,9 @@ class IsoCountryCodes # :nodoc:
     def search_by_name(str, &fallback)
       fallback ||= DEFAULT_FALLBACK
 
-      instances = all.select { |c| c.name.upcase == str.upcase }
-      instances = all.select { |c| c.name.match(/^#{Regexp.escape(str)}/i) } if instances.empty?
-      instances = all.select { |c| c.name.match(/#{Regexp.escape(str)}/i) } if instances.empty?
+      instances = all.select { |c| c.name.to_s.upcase == str.to_s.upcase }
+      instances = all.select { |c| c.name.to_s.match(/^#{Regexp.escape(str)}/i) } if instances.empty?
+      instances = all.select { |c| c.name.to_s.match(/#{Regexp.escape(str)}/i) } if instances.empty?
 
       return fallback.call "No ISO 3166-1 codes could be found searching with name '#{str}'." if instances.empty?
 
@@ -65,7 +65,7 @@ class IsoCountryCodes # :nodoc:
     def search_by_currency(code, &fallback)
       fallback ||= DEFAULT_FALLBACK
 
-      code = code.to_str.upcase
+      code = code.to_s.upcase
       instances = all.select { |c|
         c.currencies.select { |currency|
           currency != code
@@ -80,7 +80,7 @@ class IsoCountryCodes # :nodoc:
     def search_by_iban(code, &fallback)
       fallback ||= DEFAULT_FALLBACK
 
-      code = code.to_str.upcase
+      code = code.to_s.upcase
       instances = all.select { |c| c.iban == code }
 
       return fallback.call "No ISO 3166-1 codes could be found searching with IBAN '#{code}'." if instances.empty?

--- a/test/iso_country_codes_test.rb
+++ b/test/iso_country_codes_test.rb
@@ -171,11 +171,11 @@ class TestIsoCountryCodes < Test::Unit::TestCase
   end
 
   def test_search_by_iban_lowercase
-    assert_equal [IsoCountryCodes::Code::GBR.instance], IsoCountryCodes.search_by_iban('gb')
+    assert_equal [IsoCountryCodes::Code::BIH.instance], IsoCountryCodes.search_by_iban('ba')
   end
 
   def test_search_by_iban_uppercase
-    assert_equal [IsoCountryCodes::Code::GBR.instance], IsoCountryCodes.search_by_iban('GB')
+    assert_equal [IsoCountryCodes::Code::BIH.instance], IsoCountryCodes.search_by_iban('BA')
   end
 
   def test_search_by_iban_invalid_value_and_raise_exception


### PR DESCRIPTION
All three Crown Dependencies use `GB` as their IBAN code (see the United Kingdom section under http://www.swift.com/dsp/resources/documents/IBAN_Registry.pdf for more info)