### PR TITLE
Handle names with commas and parenthesis

### DIFF
--- a/lib/iso_country_codes/iso_country_codes.rb
+++ b/lib/iso_country_codes/iso_country_codes.rb
@@ -41,6 +41,7 @@ class IsoCountryCodes # :nodoc:
       instances = all.select { |c| c.name.to_s.upcase == str.to_s.upcase }
       instances = all.select { |c| c.name.to_s.match(/^#{Regexp.escape(str)}/i) } if instances.empty?
       instances = all.select { |c| c.name.to_s.match(/#{Regexp.escape(str)}/i) } if instances.empty?
+      instances = all.select { |c| word_set(c.name) == word_set(str) } if instances.empty?
 
       return fallback.call "No ISO 3166-1 codes could be found searching with name '#{str}'." if instances.empty?
 
@@ -86,6 +87,11 @@ class IsoCountryCodes # :nodoc:
       return fallback.call "No ISO 3166-1 codes could be found searching with IBAN '#{code}'." if instances.empty?
 
       instances
+    end
+
+    private
+    def word_set(str)
+      str.to_s.upcase.split(/\W/).reject(&:empty?).to_set
     end
   end
 end

--- a/test/iso_country_codes_test.rb
+++ b/test/iso_country_codes_test.rb
@@ -59,6 +59,14 @@ class TestIsoCountryCodes < Test::Unit::TestCase
     assert_equal [IsoCountryCodes::Code::AUS.instance], IsoCountryCodes.search_by_name('Australia')
   end
 
+  def test_search_comma_separated_name
+    assert_equal [IsoCountryCodes::Code::PSE.instance], IsoCountryCodes.search_by_name('State of Palestine')
+  end
+
+  def test_search_parenthetical_name
+    assert_equal [IsoCountryCodes::Code::KOR.instance], IsoCountryCodes.search_by_name('Republic of Korea')
+  end
+
   def test_search_by_name_returning_many_results_starting_wth_the_search_string
     assert_equal([
       IsoCountryCodes::Code::ARE.instance,


### PR DESCRIPTION
The source material for the library contains some names with parenthesis
or commas, like "Korea (Republic of)", this enhances `search_by_name` to
accommodate finding these when the input string is undelimited (ex.
"Republic of Korea".