### PR TITLE
Moved Code#iban from attr_accessor to attr_writer

### DIFF
--- a/lib/iso_country_codes/code.rb
+++ b/lib/iso_country_codes/code.rb
@@ -49,8 +49,8 @@ class IsoCountryCodes
     end
 
     class << self
-      attr_accessor :name, :numeric, :alpha2, :alpha3, :calling, :continent, :main_currency, :iban
-      attr_writer :currencies
+      attr_accessor :name, :numeric, :alpha2, :alpha3, :calling, :continent, :main_currency
+      attr_writer :currencies, :iban
       alias_method :currency, :main_currency
       alias_method :calling_code, :calling
 


### PR DESCRIPTION
 because it's defined later, and this was throwing a console warning.