### PR TITLE
Slovakia currency is EUR

### DIFF
--- a/lib/iso_country_codes/iso_4217.rb
+++ b/lib/iso_country_codes/iso_4217.rb
@@ -704,7 +704,7 @@ class IsoCountryCodes
       self.main_currency = 'BRL'
     end
     class SVK < Code #:nodoc:
-      self.main_currency = 'SKK'
+      self.main_currency = 'EUR'
     end
     class QAT < Code #:nodoc:
       self.main_currency = 'QAR'


### PR DESCRIPTION
Since 2009, Slovakia uses the EUR currency. See: http://www.slovak-republic.org/currency.

This PR updates the `main_currency` reference for Slovakia from `SKK` to `EUR`.