### PR TITLE
Czech Republic -> Czechia

### DIFF
--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -358,7 +358,7 @@ class IsoCountryCodes
     end
     class CZE < Code #:nodoc:
       self.numeric = %q{203}
-      self.name    = %q{Czech Republic}
+      self.name    = %q{Czechia}
       self.alpha2  = %q{CZ}
       self.alpha3  = %q{CZE}
     end


### PR DESCRIPTION
Czech Republic shortname changed to Czechia
http://www.go-czechia.com/
https://en.wikipedia.org/wiki/ISO_3166-1