### PR TITLE
Update Lithuanian currency to EUR

### DIFF
--- a/lib/iso_country_codes/iso_4217.rb
+++ b/lib/iso_country_codes/iso_4217.rb
@@ -175,7 +175,7 @@ class IsoCountryCodes
       self.main_currency = 'UGX'
     end
     class LTU < Code #:nodoc:
-      self.main_currency = 'LTL'
+      self.main_currency = 'EUR'
     end
     class MNE < Code #:nodoc:
       self.main_currency = 'EUR'


### PR DESCRIPTION
Lithuania joined euro area in January 1st, 2015 and currency was replaced with euro.

reference:
https://www.ecb.europa.eu/euro/changeover/lithuania/html/index.en.html