### PR TITLE
Add override fields capability.  Simply call TWN "Taiwan".

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -43,6 +43,20 @@ Provides ISO codes, names and currencies for countries.
 
   gem install iso_country_codes
 
+== OVERRIDES:
+
+For whatever reason, you may want to apply overrides to certain
+fields.  For example, the country name of TWN is simply "Taiwan",
+instead of "Taiwan, Province of China" like in the Wikipedia list used
+as a source, to make it less
+politicised. (https://en.wikipedia.org/wiki/Political_status_of_Taiwan#Controversies)
+
+The format of the `overrides.yml` file is the 3-letter alpha country
+code as the key, and the fields one wants to override as follows:
+
+  "TWN":
+    :name: "Taiwan"
+
 == LICENSE:
 
 (The MIT License)

--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -1306,7 +1306,7 @@ class IsoCountryCodes
     end
     class TWN < Code #:nodoc:
       self.numeric = %q{158}
-      self.name    = %q{Taiwan, Province of China}
+      self.name    = %q{Taiwan}
       self.alpha2  = %q{TW}
       self.alpha3  = %q{TWN}
     end

--- a/overrides.yml
+++ b/overrides.yml
@@ -1,0 +1,3 @@
+---
+"TWN":
+  :name: "Taiwan"

--- a/rakelib/iso_3166_1.rb
+++ b/rakelib/iso_3166_1.rb
@@ -1,6 +1,7 @@
 require 'nokogiri'
 require 'open-uri'
 require 'erubis'
+require 'yaml'
 
 class IsoCountryCodes
   module Task
@@ -40,6 +41,8 @@ class IsoCountryCodes
           end
         end
 
+        codes = recurse_merge(codes, self.exceptions)
+
         to_ruby(codes) if codes
       end
 
@@ -47,6 +50,16 @@ class IsoCountryCodes
         tmpl  = File.read(File.join(File.dirname(__FILE__), 'iso_3166_1.rb.erb'))
         eruby = Erubis::Eruby.new(tmpl)
         eruby.result(:codes => codes)
+      end
+
+      def self.exceptions
+        @config ||= YAML.load_file('overrides.yml')
+      end
+
+      def self.recurse_merge(a,b)
+        a.merge(b) do |_,x,y|
+          (x.is_a?(Hash) && y.is_a?(Hash)) ? recurse_merge(x,y) : y
+        end
       end
     end # UpdateCodes
   end # Task


### PR DESCRIPTION
Using this Gem on our e-commerce site, we've received complaints from
users in Taiwan that calling it "Taiwan, Province of China" is
politically insensitive / inflammatory.  In our codebase we're
special-casing it right now, but perhaps other users of this Gem might
not be aware of this issue either.  Therefore see attached a patch to
simply refer to it as "Taiwan".

* lib/iso_country_codes/iso_3166_1.rb: Change TW name to "Taiwan"
  only.