### PR TITLE
Skip over bogus country entries in the "Disputed" list.

### DIFF
--- a/rakelib/iso_3166_1.rb
+++ b/rakelib/iso_3166_1.rb
@@ -30,6 +30,14 @@ class IsoCountryCodes
 
             next if value == ''
 
+            # This is a terrible hack to skip the first table of the
+            # Wikipedia page, under "Naming and disputes".  The
+            # giveaway is that this table doesn't include a "Numeric
+            # code" field.
+            if key == :numeric
+              next unless value.to_i > 0
+            end
+
             value_hash[key] = value
 
             if value_hash.length == code_labels.length - 1


### PR DESCRIPTION
Previously one had to manually clean up the generated iso_3166_1.rb
file because bogus classes were generated from the first table on the
Wikipedia page https://en.wikipedia.org/wiki/ISO_3166-1.  This patch
skips over those entries.

* rakelib/iso_3166_1.rb (UpdateCodes.get): Skip bogus entries.