### PR TITLE
The international calling code for Peurto Rico is +1. 787 is area code

### DIFF
--- a/lib/iso_country_codes/calling.rb
+++ b/lib/iso_country_codes/calling.rb
@@ -73,7 +73,7 @@ class IsoCountryCodes
       self.calling = '+375'
     end
     class PRI < Code #:nodoc:
-      self.calling = '+787'
+      self.calling = '+1'
     end
     class GAB < Code #:nodoc:
       self.calling = '+241'


### PR DESCRIPTION
See https://en.wikipedia.org/wiki/Puerto_Rico for more information.
I couldn't find what the source of this information was. 
https://www.iso.org/obp/ui/#iso:code:3166:PR is what's listed on ISO info which does not contain this.

787 and 939 are are codes: https://en.wikipedia.org/wiki/Telephone_numbers_in_Puerto_Rico

This was breaking for our use case where we tried to derive country code and then pull that for validation using https://github.com/floere/phony