### PR TITLE
Fix country code on niger side

### DIFF
--- a/lib/iso_country_codes/calling.rb
+++ b/lib/iso_country_codes/calling.rb
@@ -472,7 +472,7 @@ class IsoCountryCodes
       self.calling = '+350'
     end
     class NER < Code #:nodoc:
-      self.calling = '+277'
+      self.calling = '+227'
     end
     class HTI < Code #:nodoc:
       self.calling = '+509'


### PR DESCRIPTION
### Summary
is_country_codes return +277 for niger calling code instead of +227
### Steps to Reproduce
`IsoCountryCodes.find('ne').calling ==> "+277"`
### Expected Results
`IsoCountryCodes.find('ne').calling ==> "+227"`
### Notes
You can verify the calling code for niger [here](https://en.wikipedia.org/wiki/Telephone_numbers_in_Niger ) or [here](https://en.wikipedia.org/wiki/Niger) 

**thank you for the time you took to develop and maintain this library.**