### PR TITLE
Update Vietnam name

### DIFF
--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -1450,7 +1450,7 @@ class IsoCountryCodes
     end
     class VNM < Code #:nodoc:
       self.numeric = %q{704}
-      self.name    = %q{Viet Nam}
+      self.name    = %q{Vietnam}
       self.alpha2  = %q{VN}
       self.alpha3  = %q{VNM}
     end


### PR DESCRIPTION
Vietnam is usually [written](https://en.wikipedia.org/wiki/Vietnam) without space.