### PR TITLE
Replace SVC to USD

### DIFF
--- a/lib/iso_country_codes/iso_4217.rb
+++ b/lib/iso_country_codes/iso_4217.rb
@@ -199,7 +199,7 @@ class IsoCountryCodes
       self.main_currency = 'XOF'
     end
     class SLV < Code #:nodoc:
-      self.main_currency = 'SVC'
+      self.main_currency = 'USD'
     end
     class LCA < Code #:nodoc:
       self.main_currency = 'XCD'


### PR DESCRIPTION

No longer used and replaced by USD

(https://en.wikipedia.org/wiki/Salvadoran_col%C3%B3n)